### PR TITLE
feat: add videos page for youtube channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "eslint --fix"
     ],
     "*.ts": [
-      "tsc --noEmit --skipLibCheck"
+      "sh -c \"tsc --noEmit --skipLibCheck --project tsconfig.json\""
     ],
     "src/**/*.{ts,js}": [
       "vitest related --run"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,11 @@
+---
+import { YOUTUBE_CHANNEL_URL } from '../consts';
+---
+
 <footer class="mt-16 text-sm">
   <nav class="flex gap-6">
     <a href="https://github.com/mayphus" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <a href="https://youtube.com/@mayphustang" target="_blank" rel="noopener noreferrer">YouTube</a>
+    <a href={YOUTUBE_CHANNEL_URL} target="_blank" rel="noopener noreferrer">YouTube</a>
     <a href="https://www.pinterest.com/mayphustang" target="_blank" rel="noopener noreferrer">Pinterest</a>
     <a href="mailto:tangmeifa@gmail.com">Email</a>
   </nav>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -4,6 +4,7 @@ const currentPath = Astro.url.pathname;
 const links = [
   { href: '/', label: 'Home' },
   { href: '/content/', label: 'Content' },
+  { href: '/videos/', label: 'Videos' },
 ];
 
 // Determine active link
@@ -17,8 +18,8 @@ const isActive = (href: string) => {
 <header class="org-nav">
   <nav aria-label="Primary navigation">
     {links.map((link) => (
-      <a 
-        href={link.href} 
+      <a
+        href={link.href}
         class={`org-nav-link ${isActive(link.href) ? 'active' : ''}`}
       >
         {link.label}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,3 +3,8 @@
 
 export const SITE_TITLE = "Mayphus";
 export const SITE_DESCRIPTION = "A dad, a maker, a perpetual learner";
+
+export const YOUTUBE_HANDLE = '@mayphustang';
+export const YOUTUBE_CHANNEL_URL = 'https://youtube.com/@mayphustang';
+export const YOUTUBE_SUBSCRIBE_URL = 'https://www.youtube.com/@mayphustang?sub_confirmation=1';
+export const YOUTUBE_CHANNEL_ID: string | undefined = undefined;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_YOUTUBE_CHANNEL_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/videos.test.ts
+++ b/src/lib/videos.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatVideoPublishedDate,
+  getYoutubeVideos,
+  parseYoutubeFeed,
+  serializeVideosForClient,
+  type Video,
+} from './videos';
+
+const sampleFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/">
+  <entry>
+    <id>yt:video:abc123</id>
+    <yt:videoId>abc123</yt:videoId>
+    <yt:channelId>channel-1</yt:channelId>
+    <title>Workshop Build &amp; Beyond</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=abc123"/>
+    <published>2024-01-15T12:34:56+00:00</published>
+    <updated>2024-01-15T13:00:00+00:00</updated>
+    <media:group>
+      <media:title>Workshop Build &amp; Beyond</media:title>
+      <media:description>A behind-the-scenes look at prototypes &amp; plans for what&#39;s next.</media:description>
+    </media:group>
+  </entry>
+  <entry>
+    <id>yt:video:def456</id>
+    <yt:videoId>def456</yt:videoId>
+    <yt:channelId>channel-1</yt:channelId>
+    <title>Laser Cutting Jigs</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=def456"/>
+    <published>2023-12-01T08:00:00+00:00</published>
+    <updated>2023-12-01T08:10:00+00:00</updated>
+    <media:group>
+      <media:title>Laser Cutting Jigs</media:title>
+    </media:group>
+  </entry>
+</feed>`;
+
+describe('parseYoutubeFeed', () => {
+  it('parses video entries from the feed', () => {
+    const videos = parseYoutubeFeed(sampleFeed);
+    expect(videos).toHaveLength(2);
+
+    const [first, second] = videos;
+
+    expect(first.id).toBe('abc123');
+    expect(first.title).toBe('Workshop Build & Beyond');
+    expect(first.url).toBe('https://www.youtube.com/watch?v=abc123');
+    expect(first.embedUrl).toBe('https://www.youtube.com/embed/abc123');
+    expect(first.thumbnailUrl).toBe('https://i.ytimg.com/vi/abc123/hqdefault.jpg');
+    expect(first.description).toContain('behind-the-scenes look');
+    expect(first.publishedAt?.toISOString()).toBe('2024-01-15T12:34:56.000Z');
+
+    expect(second.id).toBe('def456');
+    expect(second.description).toBeUndefined();
+  });
+
+  it('returns an empty array for missing content', () => {
+    expect(parseYoutubeFeed('')).toEqual([]);
+  });
+});
+
+describe('getYoutubeVideos', () => {
+  it('returns parsed videos when the fetch succeeds', async () => {
+    const fetchMock: typeof globalThis.fetch = async () =>
+      new globalThis.Response(sampleFeed, {
+        status: 200,
+        headers: { 'Content-Type': 'application/atom+xml' },
+      });
+
+    const videos = await getYoutubeVideos(fetchMock, 1);
+    expect(videos).toHaveLength(1);
+    expect(videos[0]?.id).toBe('abc123');
+  });
+
+  it('handles network failures gracefully', async () => {
+    const fetchMock: typeof globalThis.fetch = async () => {
+      throw new Error('network error');
+    };
+
+    const videos = await getYoutubeVideos(fetchMock);
+    expect(videos).toEqual([]);
+  });
+});
+
+describe('serializeVideosForClient', () => {
+  it('converts Date fields to ISO strings', () => {
+    const videos: Video[] = parseYoutubeFeed(sampleFeed);
+    const serialized = serializeVideosForClient(videos);
+
+    expect(serialized[0]?.publishedAt).toBe('2024-01-15T12:34:56.000Z');
+    expect(serialized[0]?.id).toBe('abc123');
+  });
+});
+
+describe('formatVideoPublishedDate', () => {
+  it('formats dates using the configured locale', () => {
+    const formatted = formatVideoPublishedDate(new Date('2024-01-15T12:34:56Z'));
+    expect(formatted).toBe('Jan 15, 2024');
+  });
+
+  it('returns undefined for missing dates', () => {
+    expect(formatVideoPublishedDate(undefined)).toBeUndefined();
+  });
+});

--- a/src/lib/videos.ts
+++ b/src/lib/videos.ts
@@ -1,0 +1,170 @@
+import { YOUTUBE_CHANNEL_ID, YOUTUBE_HANDLE } from '../consts';
+
+export interface Video {
+  id: string;
+  title: string;
+  url: string;
+  embedUrl: string;
+  thumbnailUrl: string;
+  description?: string;
+  publishedAt?: Date;
+}
+
+export interface SerializableVideo extends Omit<Video, 'publishedAt'> {
+  publishedAt?: string;
+}
+
+const DEFAULT_MAX_DESCRIPTION_LENGTH = 220;
+const HTML_ENTITY_PATTERN = /&(#x?[0-9a-fA-F]+|\w+);/g;
+const ENTRY_PATTERN = /<entry[\s\S]*?<\/entry>/gi;
+const BASE_WATCH_URL = 'https://www.youtube.com/watch?v=';
+const BASE_EMBED_URL = 'https://www.youtube.com/embed/';
+const BASE_THUMBNAIL_URL = 'https://i.ytimg.com/vi/';
+
+const htmlEntities: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: '\'',
+  nbsp: '\u00A0',
+};
+
+const youtubeUsername = YOUTUBE_HANDLE.startsWith('@')
+  ? YOUTUBE_HANDLE.slice(1)
+  : YOUTUBE_HANDLE;
+const feedCandidates = [
+  YOUTUBE_CHANNEL_ID
+    ? `https://www.youtube.com/feeds/videos.xml?channel_id=${YOUTUBE_CHANNEL_ID}`
+    : undefined,
+  youtubeUsername
+    ? `https://www.youtube.com/feeds/videos.xml?user=${youtubeUsername}`
+    : undefined,
+].filter((value): value is string => Boolean(value));
+
+const publishedFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+});
+
+function decodeHtml(value: string): string {
+  return value.replace(HTML_ENTITY_PATTERN, (_, entity) => {
+    if (!entity) return '';
+    if (entity.startsWith('#x') || entity.startsWith('#X')) {
+      const codePoint = Number.parseInt(entity.slice(2), 16);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : '';
+    }
+
+    if (entity.startsWith('#')) {
+      const codePoint = Number.parseInt(entity.slice(1), 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : '';
+    }
+
+    return htmlEntities[entity] ?? `&${entity};`;
+  });
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength = DEFAULT_MAX_DESCRIPTION_LENGTH): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}
+
+function extractTagValue(source: string, tag: string): string | undefined {
+  const pattern = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, 'i');
+  const match = source.match(pattern);
+  return match ? match[1].trim() : undefined;
+}
+
+function buildVideo(id: string, title: string, options: {
+  description?: string;
+  publishedAt?: string;
+} = {}): Video {
+  const publishedAt = options.publishedAt ? new Date(options.publishedAt) : undefined;
+  const isValidDate = publishedAt && !Number.isNaN(publishedAt.getTime());
+
+  return {
+    id,
+    title,
+    description: options.description,
+    publishedAt: isValidDate ? publishedAt : undefined,
+    url: `${BASE_WATCH_URL}${id}`,
+    embedUrl: `${BASE_EMBED_URL}${id}`,
+    thumbnailUrl: `${BASE_THUMBNAIL_URL}${id}/hqdefault.jpg`,
+  };
+}
+
+export function parseYoutubeFeed(xml: string): Video[] {
+  if (!xml) return [];
+
+  const entries = xml.match(ENTRY_PATTERN) ?? [];
+
+  return entries
+    .map((entry) => {
+      const id = extractTagValue(entry, 'yt:videoId');
+      if (!id) return undefined;
+
+      const rawTitle = extractTagValue(entry, 'title') ?? '';
+      const title = normalizeWhitespace(decodeHtml(rawTitle)) || 'Untitled video';
+
+      const rawDescription = extractTagValue(entry, 'media:description');
+      const description = rawDescription
+        ? truncate(normalizeWhitespace(decodeHtml(rawDescription)))
+        : undefined;
+
+      const publishedAt = extractTagValue(entry, 'published');
+
+      return buildVideo(id, title, {
+        description,
+        publishedAt,
+      });
+    })
+    .filter((video): video is Video => Boolean(video));
+}
+
+export async function getYoutubeVideos(
+  fetcher: typeof globalThis.fetch = globalThis.fetch,
+  limit?: number
+): Promise<Video[]> {
+  if (!fetcher) {
+    return [];
+  }
+
+  for (const url of feedCandidates) {
+    try {
+      const response = await fetcher(url);
+      if (!response.ok) {
+        continue;
+      }
+      const xml = await response.text();
+      const videos = parseYoutubeFeed(xml);
+      if (videos.length > 0) {
+        return typeof limit === 'number' ? videos.slice(0, limit) : videos;
+      }
+    } catch (error) {
+      console.warn(`[videos] Failed to load YouTube feed from ${url}:`, error);
+    }
+  }
+
+  return [];
+}
+
+export function serializeVideosForClient(videos: Video[]): SerializableVideo[] {
+  return videos.map((video) => ({
+    ...video,
+    publishedAt: video.publishedAt ? video.publishedAt.toISOString() : undefined,
+  }));
+}
+
+export function formatVideoPublishedDate(date?: Date): string | undefined {
+  if (!date) return undefined;
+  try {
+    return publishedFormatter.format(date);
+  } catch {
+    return date.toISOString().split('T')[0];
+  }
+}

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -1,0 +1,117 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import SiteHeader from '../../components/SiteHeader.astro';
+import Footer from '../../components/Footer.astro';
+import {
+  SITE_TITLE,
+  SITE_DESCRIPTION,
+  YOUTUBE_CHANNEL_URL,
+  YOUTUBE_HANDLE,
+  YOUTUBE_SUBSCRIBE_URL,
+} from '../../consts';
+import {
+  formatVideoPublishedDate,
+  getYoutubeVideos,
+  type Video,
+} from '../../lib/videos';
+
+const videos: Video[] = await getYoutubeVideos();
+const pageTitle = `Videos | ${SITE_TITLE}`;
+const pageDescription = `Watch every YouTube upload from ${SITE_TITLE}. ${SITE_DESCRIPTION}`;
+const youtubeUsername = YOUTUBE_HANDLE.startsWith('@')
+  ? YOUTUBE_HANDLE.slice(1)
+  : YOUTUBE_HANDLE;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={pageTitle} description={pageDescription} />
+  </head>
+  <body>
+    <SiteHeader />
+    <main id="main" class="org-content">
+      <section class="mb-8 space-y-4">
+        <h1>Video Library</h1>
+        <div class="org-paragraph">
+          Explore every video from my workshop, from in-progress builds to finished pieces. Each upload is mirrored here moments after it lands on <a href={YOUTUBE_CHANNEL_URL} class="org-link" target="_blank" rel="noopener noreferrer">YouTube</a>.
+        </div>
+        <div class="org-paragraph">
+          Want the updates as soon as they drop? <a href={YOUTUBE_SUBSCRIBE_URL} class="org-link" target="_blank" rel="noopener noreferrer">Subscribe on YouTube</a> and join the community.
+        </div>
+      </section>
+
+      <section class="mb-12">
+        <h2 class="text-xl font-semibold text-[color:var(--org-text-bright)] mb-4">Latest uploads</h2>
+        <div class="grid gap-6 md:grid-cols-2" data-video-grid>
+          {videos.map((video) => (
+            <article
+              class="flex h-full flex-col overflow-hidden rounded-lg border border-[color:var(--org-border)] bg-[color:var(--org-bg-alt)] shadow-sm transition duration-200 hover:-translate-y-1 hover:border-[color:var(--org-highlight)]"
+            >
+              <a
+                href={video.url}
+                class="flex h-full flex-col group"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <div class="relative aspect-video overflow-hidden bg-black">
+                  <img
+                    src={video.thumbnailUrl}
+                    alt={`Thumbnail for ${video.title}`}
+                    loading="lazy"
+                    width="640"
+                    height="360"
+                    class="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.03]"
+                  />
+                </div>
+                <div class="flex flex-1 flex-col gap-3 p-4">
+                  <h3 class="text-lg font-medium leading-snug text-[color:var(--org-text-bright)] group-hover:text-[color:var(--org-highlight)]">
+                    {video.title}
+                  </h3>
+                  {video.publishedAt && (
+                    <p class="text-xs uppercase tracking-wide text-[color:var(--org-text-dim)]">
+                      {formatVideoPublishedDate(video.publishedAt)}
+                    </p>
+                  )}
+                  {video.description && (
+                    <p class="text-sm leading-relaxed text-[color:var(--org-text)]">
+                      {video.description}
+                    </p>
+                  )}
+                  <span class="mt-auto text-sm font-medium text-[color:var(--org-link)] group-hover:text-[color:var(--org-highlight)]">
+                    Watch on YouTube →
+                  </span>
+                </div>
+              </a>
+            </article>
+          ))}
+
+          {videos.length === 0 && (
+            <p class="org-paragraph col-span-full">
+              I couldn't load the channel feed right now. Catch every episode directly on <a href={YOUTUBE_CHANNEL_URL} class="org-link" target="_blank" rel="noopener noreferrer">YouTube</a>.
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section class="mb-12 space-y-4">
+        <h2>Queue up the full playlist</h2>
+        <div class="aspect-video w-full overflow-hidden rounded-lg border border-[color:var(--org-border)] bg-black">
+          <iframe
+            src={`https://www.youtube.com/embed?listType=user&list=${youtubeUsername}`}
+            title="Mayphus Tang YouTube uploads"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+            class="h-full w-full"
+          ></iframe>
+        </div>
+        <div class="org-paragraph text-sm text-[color:var(--org-text-dim)]">
+          The embedded playlist streams every public upload in order. Use YouTube's controls to shuffle, loop, or pop the player out while you tinker.
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated /videos page that lists channel uploads and embeds the playlist
- implement a YouTube feed parser with supporting tests and channel metadata constants
- expose the Videos link in site chrome and ensure lint-staged type-checking uses the project config

## Testing
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68d01ee2c5a8833380d3efd4b9107e79